### PR TITLE
1222 quiz

### DIFF
--- a/minjoo/boj11724.java
+++ b/minjoo/boj11724.java
@@ -1,0 +1,59 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+// boj 11724 연결 요소의 개수 (재귀, 백트래킹, 전형적 그래프 탐색)
+// 3초 제한이므로 연산이 3억번 이하로 돼야 함. 메모리 제한은 512mb. 따라서 인접리스트를 쓸 예정.
+// 712ms
+public class boj11724 {
+
+  static ArrayList<Integer>[] list;
+  static boolean[] visited;
+  public static void main(String[] args) throws Exception {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    int N = Integer.parseInt(st.nextToken()); // 정점(노드)의 개수, 1~1000
+    int M = Integer.parseInt(st.nextToken()); // 간선의 개수, 0~N*(N-1)/2: 1~N-1까지의 합. 이진 트리 같은 그래프가 아니므로 간선의 개수는 1개의 노드에 N-1개가 존재 가능.
+
+    visited = new boolean[N + 1];
+    list = new ArrayList[N + 1];
+    for (int i = 0; i <= N; i++) {
+      list[i] = new ArrayList<>();
+    }
+
+    for (int i = 0; i < M; i++) {
+      st = new StringTokenizer(br.readLine());
+      int a = Integer.parseInt(st.nextToken());
+      int b = Integer.parseInt(st.nextToken());
+
+      list[a].add(b);
+      list[b].add(a);
+    }
+
+    int count = 0;
+    for (int i = 1; i <= N; i++) {
+      if (!visited[i]) {
+        dfs(i);
+        count++;
+      }
+    }
+
+    System.out.println(count);
+  }
+
+  static void dfs(int node) {
+    if (visited[node]) {
+      return;
+    }
+    visited[node] = true;
+    for (int i : list[node]) {
+      if (!visited[i]) {
+        dfs(i);
+      }
+    }
+  }
+}

--- a/minjoo/programmers_level2_124country_number.java
+++ b/minjoo/programmers_level2_124country_number.java
@@ -1,0 +1,29 @@
+package programmers;
+
+public class programmers_level2_124country_number {
+  public static void main(String[] args) {
+    System.out.println(solution(4));
+  }
+
+  public static String solution(int n) {
+    // n은 5억 이하의 자연수. 이 때, 아래의 식은 시간복잡도는 O(N/3) 밖에 되지 않으므로, 괜찮음.
+    // 제한 시간이 제시가 안 돼 있어서 O(N)으로 평범하게 생각하면 5초.... 이내에 통과하면 되는 것 같음.
+    StringBuilder sb = new StringBuilder();
+
+    int num = n;
+    while (num != 0) {
+      int front = num / 3;
+      int back = num % 3;
+      if (back == 0) {
+        // 나머지가 0일 때,
+        front = front - 1;
+        back = 4;
+      }
+
+      num = front;
+      sb.insert(0, back);
+    }
+
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
## [프로그래머스 124 나라의 숫자]

주어진 수를 3으로 나눈 몫과 나머지 값, 두 개를 구해 나머지 값을 계속해서 저장해나가는 그리디한 풀이 방식이 필요했던 문제.
표현할 수 있는 수가 **1, 2, 4로 총 3가지이므로 3진수로 풀려다가 나머지가 0이 되는 부분에서 1, 2, 3의 3진수와 차이점이 생겨** 이 부분을 알아보는 게 핵심 포인트였던 것 같습니다.

---

## [BOJ 11724 연결 요소의 개수]

전형적인 그래프 탐색 문제. DFS로 깊이 우선 탐색을 하면서 visited로 노드를 체크해, 이어진 싸이클을 모두 체크해 1개로 카운팅 해주는 방법으로 구현했습니다. 간선으로 연결된 노드를 따라 끝까지 탐색을 했어야 했으므로, BFS보다 DFS가 시간 복잡도에 더 적합하다고 생각해, 진행했습니다.
N은 최대 1000개, M은 최대 999*1000/2개로 O(V+E)의 시간복잡도를 가진 DFS의 최악은 3초를 넘어서지 않습니다.
또한, 512mb의 메모리 제한으로, N이 1000인 만큼 인접 행렬을 사용하면... 좀....