### PR TITLE
2021-12-23 목

### DIFF
--- a/soyeon/BackJoon_11724_NumberOfConnectingElements.java
+++ b/soyeon/BackJoon_11724_NumberOfConnectingElements.java
@@ -1,0 +1,63 @@
+package backJoon_11724_NumberOfConnectingElements;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * 일    시: 2021-12-22
+ * 작 성 자: 유 소 연
+ * https://www.acmicpc.net/problem/11724
+ * */
+public class BackJoon_11724_NumberOfConnectingElements {
+	static int N, M, cnt;
+	static List<List<Integer>> list = new ArrayList<>(); // 연결관계
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		// N: 정점의 개수, M: 간선의 개수
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		visited = new boolean[N+1]; // 1~N노드 체크
+		// list 공간할당
+		for (int i = 0; i <= N; i++) {
+			list.add(new ArrayList<>());
+		}
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			list.get(a).add(b);
+			list.get(b).add(a);
+		}
+		// end of input
+		
+		// visited가 없는 노드만 타고들어간다. 빠져나오게 되면 cnt++
+		for (int i = 1; i < list.size(); i++) {
+//			System.out.printf("%d번 노드\n", i);
+			if(visited[i]) continue;
+			cnt++;
+			visited[i] = true;
+//			System.out.printf("[%d] %d번 노드 타고들어감\n", cnt, i);
+			dfs(i); // i번 노드부터 시작
+		}
+		System.out.println(cnt);
+	} // end of main
+
+	private static void dfs(int cur) {
+		List<Integer> next = list.get(cur);
+//		System.out.printf("%d와 연결된 노드들: ", cur);
+//		System.out.println(next);
+		for (int i = 0; i < next.size(); i++) {
+			if(visited[next.get(i)]) continue;
+			visited[next.get(i)] = true;
+			dfs(next.get(i));
+		}
+	} // end of dfs
+} // end of class

--- a/soyeon/Programmers_12899_numberOf124Country.java
+++ b/soyeon/Programmers_12899_numberOf124Country.java
@@ -1,0 +1,25 @@
+package programmers_12899_numberOf124Contry;
+/**
+ * 일    시: 2021-12-23
+ * 작 성 자: 유 소 연
+ * https://programmers.co.kr/learn/courses/30/lessons/12899
+ * */
+public class Programmers_12899_numberOf124Country {
+	public String solution(int n) {
+        // 나머지는 뒤에 붙이고, 몫이 0이 아니면 계속 나누고 붙이는것을 반복한다.
+        // dp로 풀려고 했으나 n이 5억이라 규칙이 반드시 존재할 것이라 생각
+        
+        // 이 부분 int형 배열로 했더니 효율성에서 시간초과남.
+        String[] num = {"4","1","2"}; // 나머지 0->4, 1->1, 2->2로 변환
+        int m = n; // 몫
+        int r = 0; // 나머지
+        String ans = "";
+        while(m > 0) {
+            r = m%3;
+            if(r==0) m--;
+            m /= 3;
+            ans = num[r]+ans;
+        } // end of while
+        return ans;
+    } // end of solution
+} // end of class


### PR DESCRIPTION
### [124나라의 숫자]
1. 처음에 dp로 풀려고 생각했으나, n의 범위가 5억까지라 규칙이 반드시 존재할 것이라 생각했습니다.
2. 뒤에서부터 n의 나머지를 붙이고, 몫이 0이 아니면 계속 나누고 붙여나가는 것을 반복합니다.
3. **{시간복잡도} n을 3씩 나누는 횟수가 시간복잡도이므로 O(n/3) => 1억이 넘게 되지만, 한번씩 3으로 나눌수록 점점 작아져서 실제론 1억이 안나오기 때문에 충분하다고 생각했습니다.**
4. num 배열을 처음에 int[] 형으로 풀었더니 효율성 체크에서 시간초과가 발생했습니다.
아마도 ans에 붙이는 과정에서 int->String으로 변환하기 때문인 것 같았습니다.
-------------------
 
### [연결 요소의 개수]
1. 정점의 개수 N이 1부터 1000까지이기 때문에, 인접행렬보다는 인접리스트로 푸는것이 적절하다고 생각했습니다.
2. **{시간복잡도} 간선의 개수 M이 N(N-1)/2 이기 때문에 완탐해도 충분하다고 생각했습니다.**
3. 1번노드부터 꼬리에 꼬리를 물며 dfs로 타고 들어가고, 타고 들어갈 때 카운트+1 해줍니다. 탐색하며 visited로 중복체크를 해줍니다.