### PR TITLE
 1223

### DIFF
--- a/moontek/연결요소의개수.java
+++ b/moontek/연결요소의개수.java
@@ -1,0 +1,55 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+
+
+public class 연결요소의개수 {
+
+	static int N;
+	static boolean[] visited;
+	static LinkedList<Integer>[] array;
+	public static void main(String[] args) throws IOException {
+		// TODO Auto-generated method stub
+		BufferedReader br =new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		array = new LinkedList[N+1];
+		for(int i=0;i<=N;i++) {
+			array[i] = new LinkedList<>();
+		}
+		visited = new boolean[N+1];
+		for(int i=0;i<M;i++) {
+			st = new StringTokenizer(br.readLine());
+			int start = Integer.parseInt(st.nextToken());
+			int end = Integer.parseInt(st.nextToken());
+			array[start].add(end);
+			array[end].add(start);
+		}
+		int count=0;
+		for(int i=1;i<=N;i++) {
+			if(!visited[i]) {
+				visited[i] = true;
+				dfs(i);
+				count++;
+			}
+		}
+		System.out.println(count);
+		
+	}
+	private static void dfs(int i) {
+		// TODO Auto-generated method stub
+		for(int k : array[i]) {
+			if(!visited[k]) {
+				visited[k] = true;
+				dfs(k);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
### [연결 요소의 개수]
1. 무지성 DFS 시 스택오버플로우 간단히 visited 배열에 넣어서 방문체크 
2. 무방향 그래프이므로 배열이나 인접리스트 이용시 시작과 끝 둘다 간선의 값을 넣어줘야함 
3.  시간복잡도는 정점의 개수 V 간선의 개수 E 라고 했을때 인접리스트 구현이므로 O(V+E) 
-------------------