### PR TITLE
1228

### DIFF
--- a/moontek/뉴스클러스터링.java
+++ b/moontek/뉴스클러스터링.java
@@ -1,0 +1,78 @@
+package Programmers;
+
+import java.util.ArrayList;
+
+public class 뉴스클러스터링 {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+
+		String str1 = "e=m*c^2";
+		String str2 = "E=M*C^2";
+		System.out.println(solution(str1,str2));
+	}
+    static public int solution(String str1, String str2) {
+        int answer = 0;
+        
+        String nstr1 = str1.toLowerCase();
+        String nstr2 = str2.toLowerCase();
+        
+        int length1 = nstr1.length();
+        int length2 = nstr2.length();
+        
+        if(length1==length2 && length1==0) {
+        	return 65536;
+        }
+        ArrayList<String> str1a = new ArrayList<>();
+        for(int i=0;i<length1-1;i++) {
+        	int sn = nstr1.charAt(i);
+        	int en = nstr1.charAt(i+1);
+        	if(sn<97 || sn>122 || en<97 || en>122) {
+        		continue;
+        	}
+        	String word = ""+nstr1.charAt(i) + nstr1.charAt(i+1);
+        	str1a.add(word);
+        }
+        
+        int na = str1a.size();
+        int nb = 0;
+        int mid = 0;
+        for(int i=0;i<length2-1;i++) {
+        	int sn = nstr2.charAt(i);
+        	int en = nstr2.charAt(i+1);
+        	if(sn<97 || sn>122 || en<97 || en>122) {
+        		continue;
+        	}
+        	
+        	String word = ""+nstr2.charAt(i) + nstr2.charAt(i+1);
+        	nb++;
+        	int index = -1;
+        	for(int j=0;j<str1a.size();j++) {
+        		if(str1a.get(j).equals(word)) {
+        			mid++;
+        			index = j;
+        			break;
+        		}
+        	}
+        	if(index!=-1) {
+        		str1a.remove(index);
+        	}
+        }
+        if(na==nb&& na==0) {
+        	return 65536;
+        }
+       
+        int total = na+nb-mid;
+        double q = (double) mid/total * 65536;
+        answer = (int) q;
+        
+
+        
+        // 소문자 97~122
+        return answer;
+        
+        
+        
+        
+    }
+}

--- a/moontek/집합의표현.java
+++ b/moontek/집합의표현.java
@@ -1,0 +1,67 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 집합의표현 {
+
+	
+	static void make() {
+		p = new int[n+1];
+		for(int i=1;i<=n;i++) {
+			p[i] = i;
+		}
+	}
+	
+	static int find(int x) {
+		if(p[x]==x) return x;
+		return p[x] = find(p[x]);
+	}
+	
+	
+	
+	static void union(int x,int y) {
+		int px = find(x);
+		int py = find(y);
+		if(px!=py) {
+			p[py] = px;
+		}
+	}
+	
+	
+	
+	static int[] p;
+	static int n;
+	public static void main(String[] args) throws IOException {
+		// TODO Auto-generated method stub
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		StringBuilder sb = new StringBuilder();
+		make();
+		for(int i=0;i<m;i++) {
+			st = new StringTokenizer(br.readLine());
+			int type = Integer.parseInt(st.nextToken());
+			int start = Integer.parseInt(st.nextToken());
+			int end = Integer.parseInt(st.nextToken());
+			
+			if(type==0) {
+				union(start,end);
+			}
+			else {
+				if(find(start)==find(end)) {
+					sb.append("YES").append("\n");
+				}
+				else {
+					sb.append("NO").append("\n");
+				}
+			}
+		}
+		System.out.println(sb);
+		
+	}
+
+}

--- a/moontek/행렬테두리회전하기.java
+++ b/moontek/행렬테두리회전하기.java
@@ -1,0 +1,82 @@
+package Programmers;
+
+import java.util.Arrays;
+
+public class 행렬테두리회전하기 {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		int[][] q = new int[][] {
+			{2,2,5,4},{3,3,6,6},{5,1,6,3}
+		};
+		
+		Arrays.toString(solution(6,6,q));
+		System.out.println("Ss");
+	}
+	  public static int[] solution(int rows, int columns, int[][] queries) {
+	        int size = queries.length;
+		  	int[] answer = new int[size];
+	        
+	        
+		  	int array[][] = new int[rows][columns];
+		  	
+		  	int start = 0;
+		  	for(int i=0;i<rows;i++) {
+		  		for(int j=0;j<columns;j++) {
+		  			array[i][j] = ++start;
+		  		}
+		  	}
+		  	
+		  	for(int i=0;i<rows;i++) {
+		  		for(int j=0;j<columns;j++) {
+		  			System.out.print(array[i][j] + " ");
+		  		}
+		  		System.out.println();
+		  	}
+	        System.out.println(queries.length);
+	        
+	        for(int i=0;i<size;i++) {
+	        	int min = Integer.MAX_VALUE;
+	        	int sx = queries[i][0]-1;
+	        	int sy = queries[i][1]-1;
+	        	int ex = queries[i][2]-1;
+	        	int ey = queries[i][3]-1;
+	        	
+	        	
+	        	
+	        	
+	        	int save = array[sx][sy]; 
+	        	
+	        	for(int j=sx;j<ex;j++) {
+	        		array[j][sy] = array[j+1][sy];
+	        		min = Math.min(array[j][sy], min);
+	        	}
+	        	
+	        	for(int j=sy;j<ey;j++) {
+	        		array[ex][j]= array[ex][j+1];
+	        		min = Math.min(array[ex][j], min);
+	        	}
+	        	
+	        	for(int j=ex;j>sx;j--) {
+	        		array[j][ey] = array[j-1][ey];
+	        		min = Math.min(array[j][ey], min);
+	        	}
+	        	for(int j=ey;j>sy;j--) {
+	        		array[sx][j] = array[sx][j-1];
+	        		min = Math.min(array[sx][j], min);
+	        	}
+	        	array[sx][sy+1] = save;
+	        	min = Math.min(save, min);
+	        	answer[i] = min;
+	        	
+	          	for(int a=0;a<rows;a++) {
+			  		for(int b=0;b<columns;b++) {
+			  			System.out.print(array[a][b] + " ");
+			  		}
+			  		System.out.println();
+			  	}
+	        }
+	        
+	        return answer;
+	    }
+}


### PR DESCRIPTION
### 행렬테두리
저번에 미작성한 부분 재업 

### 뉴스클러스트링
자르고 비교하고 더하고 연산후 개수파악 
n(A U B) = n(A) + n(B) - n(A∩B) 
O(N^2) ==>  (N+1)번비교 *2 + 각 항목에 대해 비교 (N+1)*(N+1) =>O(N^2) 

### 집합의표현
단순 disjoint 구현 
출처 ) https://www.secmem.org/blog/2021/04/19/Union-Find-Time-Complexity-Proof/ 

유니온파인드 시간복잡도 결과 M 번에 걸친 Find 연산에서 “v→ 루트” 로의 경로를 이루는 간선의 가짓수의 총합은 
O(M)+O(Mlog⋆N)+O(Nlog⋆N)=O((M+N)log⋆N) 개이고,M번의 Find 연산의 총 시간 복잡도 또한 O((M+N)log⋆N)
이다. 따라서 연산 하나의 평균 시간 복잡도는 O(log⋆N)
