### PR TITLE
2021-01-01 토

### DIFF
--- a/soyeon/BackJoon_11399_ATM.java
+++ b/soyeon/BackJoon_11399_ATM.java
@@ -1,0 +1,61 @@
+package backJoon_11399_ATM;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+/**
+ * 일    시: 2022-01-04
+ * 작 성 자: 유 소 연
+ * https://www.acmicpc.net/problem/11399
+ * */
+public class BackJoon_11399_ATM {
+	static int N;
+	static int[] time;
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		// 각 사람이 돈을 인출하는데 필요한 시간 합의 '최솟값'을 구하라
+		// N과 P의 범위가 1000까지라 순열로 절대 구할 수 없다.
+		// 고로 time 오름차순 정렬해서 구해야함...ㅠㅠ
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		// N : 사람의 수
+		N = Integer.parseInt(br.readLine());
+		init();
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		// time
+		for (int i = 0; i < N; i++) {
+			time[i] = Integer.parseInt(st.nextToken());
+		}
+		// end of input
+		
+		Arrays.sort(time);
+//		System.out.println(Arrays.toString(time));
+		int res = getTime();
+		System.out.println(res);
+		
+	} // end of main
+	
+
+	/** order대로 시간을 누적해 더함 */
+	private static int getTime() {
+		int res = 0;
+		int sum = 0;
+		for (int i = 0; i < N; i++) {
+			sum += time[i];
+			res += sum;
+//			System.out.printf("sum: %d, res: %d\n", sum,res);
+		}
+		return res;
+	}
+	
+	
+	/** 객체 초기화 */
+	private static void init() {
+		time = new int[N];
+	}
+	
+} // end of class

--- a/soyeon/Programmers_64065_Tuple.java
+++ b/soyeon/Programmers_64065_Tuple.java
@@ -1,0 +1,70 @@
+package programmers_64065_Tuple;
+import java.util.*;
+/**
+ * 일    시: 2022-01-04
+ * 작 성 자: 유 소 연
+ * https://programmers.co.kr/learn/courses/30/lessons/64065
+ * */
+class Solution {
+	 public int[] solution(String s) {
+	     // replace로 { } 다 없애버림
+	     s = s.replace("{", "");
+	     s = s.replace("}", "");
+	     
+	     // , 만 남으면 charAt 으로 읽으며 수만 map에 주워담음. 개수도 셈.
+	     Map<Integer, Integer> map = new HashMap<>();
+	     map = putInMap(s);
+	     
+	     // 내림차순정렬을 위해 리스트에 옮김
+	     List<int[]> list = new ArrayList<>();
+	     list = putInList(map);
+	     
+	     // 개수 기준 내림차순
+	     Collections.sort(list, new Comparator<int[]>(){
+	        @Override
+	         public int compare(int[] o1, int[] o2) {
+	             return o2[1] - o1[1];
+	         }
+	     });
+	     
+	     // 배열로 담음
+	     int[] ans = new int[list.size()];
+	     for(int i = 0; i < list.size(); i++) {
+	         ans[i] = list.get(i)[0];
+	     }
+	     
+	     return ans;
+	 } // end of solution
+	 
+	 
+	 /** s -> map */
+	 public Map<Integer, Integer> putInMap (String s) {
+	     Map<Integer, Integer> map = new HashMap<>();
+	     
+	     // s 에서 , 기준으로 숫자만 담음
+	     String[] numbers = s.split(",");
+	     
+	     for(int i = 0; i < numbers.length; i++) {
+	         int key = Integer.parseInt(numbers[i]);
+	         if(map.size()==0) {
+	             map.put(key, 1);
+	         } else if(map.containsKey(key)) {
+	             int value = map.get(key);
+	             map.put(key, value+1);
+	         } else {
+	             map.put(key, 1);
+	         }
+	     }
+	     return map;
+	 } // end of putInMap
+	 
+	 
+	 /** map -> list */
+	 public List<int[]> putInList(Map<Integer, Integer> map) {
+	     List<int[]> list = new ArrayList<>();
+	     for(Map.Entry<Integer, Integer> entry : map.entrySet()) {
+	         list.add(new int[]{entry.getKey(), entry.getValue()});
+	     }
+	     return list;
+	 }
+}


### PR DESCRIPTION
### [수식 최대화]

**<시간복잡도>**
expression의 길이가 100이하로 굉장히 작기 때문에 시간복잡도를 크게 신경쓰지 않았습니다.

**<풀이방식>**
1. 처음에 문자열로 접근했으나
2. 그럴 경우 너무 많은 예외들이 생깁니다.
3. (100-109)*3 일 경우 -8*3 이 되는데, 그럴 경우 다음 연산할 범위를 구하는 데 있어 너무 많은 것을 고려해야 함
4. 따라서 **ArrayList** 를 사용하니 매우 쉽게 풀렸습니다ㅠ

**<주의할점>**
1. `go()` 에서, 앞에서부터 우선순위연산자를 탐색하며 연산할 경우,
2. 예를들어 `2 x 2 x 2 x 2 x 2 - 2 x 2 x 2 ` 일 경우,

> (2 x 2) x 2 x 2 x 2 - 2 x 2 x 2 
> 
> (**4** x 2) x 2 x 2 - 2 x 2 x 2 
> 
> (**8** x 2) x 2 - 2 x 2 x 2 
> 
> (**16** x 2) - 2 x 2 x 2 
> 
> **32** - (2 x 2) x 2 
> 
> 32 - (**4** x 2) 
> 
> 32 - **8** 
> 
> **24**

이런식으로 나와야 하는데 `i=0`을 해주지 않으면

> (2 x 2) x 2 x 2 x 2 - 2 x 2 x 2 
>
> **4** x (2 x 2) x 2 - 2 x 2 x 2 
>
> 4 x **4** x 2 - (2 x 2) x 2 
>
> 4 x 4 x (2 - **4**) x 2 
>
> (4 x 4) x **-2** x 2 
>
> **16** x -(2 x 2) 
>
> 16 x -**4** 
>
> **-64**

이런식으로 건너뛰며 계산된 결과가 나오게 된다.

2. 연산되는 숫자의 크기가 long의 범위에서 나올 수 있는데, `calc()` 에서 Long으로 바꿔주지 않고 습관대로 Integer로 바꿔버려서 몇몇 테케가 틀리는 결과를 낳았습니다.

--------------

### [튜플]

**<시간복잡도>**
문자열 `s`의 길이가 100만이므로, 기껏해야 100만개를 한 번 탐색하며, 맵에서 리스트로 옮기고 정렬하는 것이 다이기 때문에
시간복잡도는 O(N+N+NlogN) 으로 충분하다고 생각했습니다.

**<풀이방식>**
문자열 `s`의 `{`와 `}`을 replace()로 날려버리고 `,` 기준으로 split()으로 숫자만 분리했습니다.

같은 부분집합임에도 정답 배열 원소의 순서는 같아야 할 것 같아서 순서의 기준을 찾은 결과,
가장 많이 나온 개수 순서인 것 같아 Map에 key로는 해당 원소를, value로는 해당 원소가 나온 횟수를 저장해주었습니다.

그리고 많이 나온 순대로 정렬하기 위해 Map을 List로 옮기고, 정렬한다음 다시 배열로 담아주었습니다.

--------------

### [ATM]

**<시간복잡도>**
사람의 수 N과 돈을 인출하는데 걸리는 시간 P의 길이가 최대 1000이므로 절대로 순열을 사용한 완전탐색 방식으론 정답을 구할 수 없습니다.
그리디하게 접근하여야 하는 문제이고, 그 기준이 P를 작은 순대로 더해나가는 방식이므로
P를 오름차순 정렬한 후, 그대로 누적하고, 그 누적합을 또 더해 정답을 구합니다.
때문에 시간복잡도는 O(NlogN+N)

