### PR TITLE
20220223

### DIFF
--- a/minjoo/boj11049.java
+++ b/minjoo/boj11049.java
@@ -1,0 +1,39 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// boj 11049 행렬 곱셈 순서(dp)
+// 252ms
+public class boj11049 {
+  public static void main(String[] args) throws Exception {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st;
+
+    int N = Integer.parseInt(br.readLine());    // 행렬의 개수. 1 ~ 500
+    int max = 123_456_789;
+
+    int[] arr = new int[N+1];
+    for (int i = 0; i < N; i++) {
+      st = new StringTokenizer(br.readLine());
+      arr[i] = Integer.parseInt(st.nextToken());      // r, c 1~500사이의 수
+      arr[i + 1] = Integer.parseInt(st.nextToken());
+    }
+    
+    int[][] dp = new int[N][N]; // 앞뒤로 한 번씩 곱한거 저장하기
+
+    for (int i = 2; i < N + 1; i++) {
+      // Bottom-Up 방식
+      for (int j = 0; j < N - i + 1; j++) {
+        dp[j][j + i - 1] = max;
+        for (int k = j; k < j + i - 1; k++) {
+          int val = dp[j][k] + dp[k + 1][j + i - 1] + (arr[j] * arr[k + 1] * arr[j + i]);
+          dp[j][j + i - 1] = Math.min(dp[j][j + i - 1], val);
+        }
+      }
+    }
+
+    System.out.println(dp[0][N-1]);
+  }
+}

--- a/minjoo/programmers_level2_emergencyBoat.java
+++ b/minjoo/programmers_level2_emergencyBoat.java
@@ -1,0 +1,20 @@
+package programmers;
+
+import java.util.Arrays;
+
+// 프로그래머스 구명보트(그리디)
+public class programmers_level2_emergencyBoat {
+  public int solution(int[] people, int limit) {
+    Arrays.sort(people);
+    int i = 0, j = people.length - 1;
+
+    // * 만약 두 명의 사람이 구명보트에 탈 수 있다면, 2명의 사람이 1개의 그룹으로 묶이는 것이므로,
+    // * 전체 사람의 수에서 -1을 해주면 일단 i번째 사람까지 짝을 이룰 수 있는지 따졌을 때의
+    // * 구명보트 개수가 나옴
+    for (; i < j; j--) {
+      if (people[i] + people[j] <= limit)
+        i++;
+    }
+    return people.length - i;
+  }
+}


### PR DESCRIPTION
## [BOJ 11049 행렬 곱셈 순서]

DP 문제

---

## [프로그래머스 구명보트]

그리디 문제로 시간복잡도가 O(N)이 나와 연산 5만회 = 만분의 5초 정도 밖에 나오지 않는다.
구명보트가 나오는 개수를 수식화 하면 풀 수 있는 문제로, 만약 2명의 사람이 같이 구명보트를 탈 수 있다면 2명이 1명으로 줄고, 같이 탈 수 없다면 2명이 그대로 2명인 것이므로 이를 수식화한 게 i와 j이다.

중요한 점은 **Arrays.sort()로 people 배열을 정렬해줘야 하는데, 이유는 아직 안 탄 사람 중에서 가장 가벼운 사람과 가장 무거운 사람이 함께 탈 수 있어야 다음 페어가 지어질 수 있기 때문.** 최소 구명보트 개수를 구해야 하는 점에 주목해야 한다.